### PR TITLE
Make python-lzo optional again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ install:
     - conda create --yes -n testenv python=$TRAVIS_PYTHON_VERSION Cython numpy nose
     - source activate testenv
     - python setup.py build_ext --inplace
-    - python setup.py install
+    - pip install .[lzo]
 script: 
     - nosetests

--- a/lib/bx/misc/seeklzop.py
+++ b/lib/bx/misc/seeklzop.py
@@ -10,8 +10,6 @@ import sys
 from six import Iterator
 
 try:
-    import pkg_resources
-    pkg_resources.require( 'python_lzo' )
     import lzo
 except:
     pass

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,13 @@ from setuptools import *
 from glob import glob
 
 def main():
-
-    build_requires = [ 'python-lzo', 'numpy' ]
-
     metadata = \
       dict( name = "bx-python",
-            version = "0.8.1",
-            install_requires=build_requires + ['six'],
+            version = "0.8.2",
+            install_requires=['numpy', 'six'],
+            extras_require={
+                'lzo': ['python-lzo']
+            },
             py_modules = [ 'psyco_full' ],
             package_dir = { '': 'lib' },
             package_data = { '': ['*.ps'] },
@@ -102,9 +102,11 @@ command_classes['build_py'] = build_py
 
 # Use epydoc if found
 try:
-    import pkg_resources
-    pkg_resources.require( "epydoc" )
-    import epydoc.cli, sys, os, os.path
+    import os
+    import os.path
+    import sys
+
+    import epydoc.cli
     # Create command class to build API documentation
     class BuildAPIDocs( Command ):
         user_options = []


### PR DESCRIPTION
Install can be asked with:
```
pip install bx-python[lzo]
```

The goal is to reduce the number of compiled Galaxy dependencies, as requested by @natefoo.