### PR TITLE
Fix loop counter in bpt_file.pyx

### DIFF
--- a/lib/bx/bbi/bpt_file.pyx
+++ b/lib/bx/bbi/bpt_file.pyx
@@ -54,7 +54,7 @@ cdef class BPTFile:
             self.reader.read( self.key_size )
             offset = self.reader.read_uint64()
             # Loop until correct subtree is found
-            for i from 0 <= i < child_count:
+            for i from 0 <= i < child_count - 1:
                 node_key = self.reader.read( self.key_size )
                 if node_key > key:
                     break


### PR DESCRIPTION
[In `bpt_file.pyx` line 53-55](https://github.com/bxlab/bx-python/blob/ed867d57f9b2e0cbed47d2f2f38d60ac4f36d79c/lib/bx/bbi/bpt_file.pyx#L53-L55), first key is already read so the number of loop counter in the following for loop must be reduced.
Perhaps this issue is related to #13.