### PR TITLE
Add missing ``build_ext`` step before creating sdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,20 @@ language: python
 cache: pip
 os:
   - linux
-  # - osx
 python:
   - '2.7'
   - '3.5'
 
 env:
   global:
+    - PYTHON=python
     - TWINE_USERNAME=nsoranzo
     - secure: 'kFoqHCxat/ETS2SUc2q9M7YvzvnlR7sgHmx7SRvVgTyLkk1efpJ++YPwDBEYZ3v+GLf2nRfc20GxtZkH6ey1f//aj4CT2q2CJiUsKAlkFAOHzKo/3mTLl/WDHkPAr9MW7AdnbNk6W8sIPCKqFsyKL2FTH70dBcxa1e7trQ2RC64hnOOkt/tm2cQhj6sX0gROggN5QrpHE8tDZb9ugF0uf92L/CGxeClAebWgb7zVChHDMTNsmnOvWUF9m6LZOvkgFmuIeh70EPuOWh6LxU/n5JyevYIGO5vVDbjgfmNELlG2KUTm6dWeoyofcj6hUqYmQsmI1ATrf7ThY1+b6asQGy+Exp/76MBXiYRh+RgVKifwaZMOWehzfjDQvPYOGvf6rXOVGeVZ+nBkskr0HARsX1KnyDE+k+XPoP7zqvW6mCic9ZQ+IdQJtxMHOTxxFjuPAlunvaUqDNM9VP6YEWOI4UqIOO1nQh4E2zkPhXI2yY744q+BV/5+3HHqNQj1+5qFPoZeyDEuNXwgDCjrJ8i3hna/LTTvRigx6/YQL1PF/C30R4h/nkqp8ghA4VpNRPnQ8nOO+oD6AdN7Pswc3C4qGPEwoeqfNzEIR1KfEWzB7HsfTFbgyGFFNGuQ/P26DMK+kPBNZ6GhZ9wb5/xT226OA+ovcAmVGn/Hnt/qVaylXNk='
 
 _deploy_common: &deploy_common
   if: tag IS present
-  addons: {}
   install:
-    - pip3 install cibuildwheel twine
-  script:
-    - python3 setup.py sdist
-    - cibuildwheel --output-dir dist
-    - twine check dist/*
-    - twine upload --skip-existing dist/*
+    - $PYTHON -m pip install cibuildwheel twine
 
 matrix:
   include:
@@ -31,11 +25,25 @@ matrix:
         - docker
       env: CIBW_BEFORE_BUILD="yum install -y zlib-devel && pip install Cython numpy"
       <<: *deploy_common
+      script:
+        - cibuildwheel --output-dir dist
+        - $PYTHON -m pip install Cython nose numpy python-lzo six
+        - $PYTHON setup.py build_ext --inplace
+        - $PYTHON setup.py sdist
+        - twine check dist/*
+        - twine upload --skip-existing dist/*
     - stage: deploy
       os: osx
       language: generic
-      env: CIBW_BEFORE_BUILD="pip install Cython numpy"
+      env:
+        - PYTHON=python3
+        - CIBW_BEFORE_BUILD="pip install Cython numpy"
+      addons: {}
       <<: *deploy_common
+      script:
+        - cibuildwheel --output-dir dist
+        - twine check dist/*
+        - twine upload --skip-existing dist/*
 
 addons:
   apt:
@@ -43,9 +51,9 @@ addons:
       - liblzo2-dev
 
 install:
-  - pip install Cython nose numpy python-lzo six
-  - python setup.py build_ext --inplace
-  - python setup.py install
+  - $PYTHON -m pip install Cython nose numpy python-lzo six
+  - $PYTHON setup.py build_ext --inplace
+  - $PYTHON setup.py install
 
 script:
   - nosetests


### PR DESCRIPTION
The auto-generated bx-python-0.8.3.tar.gz on PyPI is broken, missing `.c` files which should have been generated from `.pyx` files.