### PR TITLE
Bigwig headers extraction

### DIFF
--- a/lib/bx/bbi/bigwig_file.pyx
+++ b/lib/bx/bbi/bigwig_file.pyx
@@ -212,4 +212,3 @@ cdef class BigWigFile( BBIFile ):
 
 
 
-

--- a/lib/bx/bbi/bigwig_file.pyx
+++ b/lib/bx/bbi/bigwig_file.pyx
@@ -123,7 +123,37 @@ cdef class ArrayAccumulatingBlockHandler( BigWigBlockHandler ):
         for i from s - self.start <= i < e - self.start:
             array[ i ] = val
 
-cdef class BigWigFile( BBIFile ): 
+cdef class BigWigHeaderBlockHandler( BigWigBlockHandler ):
+    "Reads and returns headers"
+    cdef list headers
+
+    def __init__( self, bits32 start, bits32 end ):
+        BigWigBlockHandler.__init__( self, start, end )
+        self.headers = []
+
+    cdef handle_block( self, bytes block_data, BBIFile bbi_file ):
+        cdef bits32 b_chrom_id, b_start, b_end, b_valid_count
+        cdef bits32 b_item_step, b_item_span
+        cdef bits16 b_item_count
+        cdef UBYTE b_type
+        cdef int s, e
+        cdef float val
+        # Now we parse the block, first the header
+        block_reader = BinaryFileReader( BytesIO( block_data ), is_little_endian=bbi_file.reader.is_little_endian )
+        b_chrom_id = block_reader.read_uint32()
+        b_start = block_reader.read_uint32()
+        b_end = block_reader.read_uint32()
+        b_item_step = block_reader.read_uint32()
+        b_item_span = block_reader.read_uint32()
+        b_type = block_reader.read_uint8()
+        block_reader.skip(1)
+        b_item_count = block_reader.read_uint16()
+        self.handle_header( b_start, b_end,  b_item_step, b_item_span, b_type, b_item_count )
+
+    cdef handle_header( self, bits32 start, bits32 end, bits32 step, bits32 span, bits8 type, bits16 itemCount ):
+        self.headers.append( ( start, end, step, span, type, itemCount ) )
+
+cdef class BigWigFile( BBIFile ):
     """
     A "big binary indexed" file whose raw data is in wiggle format.
     """
@@ -140,7 +170,7 @@ cdef class BigWigFile( BBIFile ):
         for i from 0 <= i < summary_size:
             v.sd.valid_count[i] = round( v.sd.valid_count[i] )
         return v.sd
-        
+
     cpdef get( self, char * chrom, bits32 start, bits32 end ):
         """
         Gets all data points over the regions `chrom`:`start`-`end`.
@@ -166,6 +196,16 @@ cdef class BigWigFile( BBIFile ):
         v = ArrayAccumulatingBlockHandler( start, end )
         self.visit_blocks_in_region( chrom_id, start, end, v )
         return v.array
+
+    cpdef get_headers( self, char * chrom, bits32 start, bits32 end ):
+        if start >= end:
+            return None
+        chrom_id, chrom_size = self._get_chrom_id_and_size( chrom )
+        if chrom_id is None:
+            return None
+        v = BigWigHeaderBlockHandler( start, end )
+        self.visit_blocks_in_region( chrom_id, start, end, v )
+        return v.headers
 
 
 

--- a/lib/bx/bbi/bigwig_file.pyx
+++ b/lib/bx/bbi/bigwig_file.pyx
@@ -138,7 +138,7 @@ cdef class BigWigHeaderBlockHandler( BigWigBlockHandler ):
         cdef UBYTE b_type
         cdef int s, e
         cdef float val
-        # Now we parse the block, first the header
+        # parse the block header
         block_reader = BinaryFileReader( BytesIO( block_data ), is_little_endian=bbi_file.reader.is_little_endian )
         b_chrom_id = block_reader.read_uint32()
         b_start = block_reader.read_uint32()


### PR DESCRIPTION
Hi,
at the University of Oslo, we are working on a tool for expressive file formats for analysis of genomic track data (https://github.com/gtrack/gtrackcore) and one of the file formats supported is BigWig. As we are basically converting different file formats to a somewhat universal representation we had quite a specific needs for parsing of BigWig files. I found your library and made a small addition that allows to extract and return several fields from a BigWig header, hoping this could be merged to your library so we can later use pip/conda to install it on client side.

Radmila 