### PR TITLE
Use chain.from_iterable in bed_coverage.py

### DIFF
--- a/scripts/bed_coverage.py
+++ b/scripts/bed_coverage.py
@@ -16,7 +16,7 @@ from bx.bitset_builders import binned_bitsets_from_file
 
 bed_filenames = sys.argv[1:]
 if bed_filenames:
-    input = chain(* (open(_) for _ in bed_filenames))
+    input = chain.from_iterable(map(open, bed_filenames))
 else:
     input = sys.stdin
 


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.