### PR TITLE
Added ref to Debian package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It is available in [bioconda](https://anaconda.org/bioconda/bx-python) (recommen
 
 ```conda install -c conda-forge -c bioconda bx-python```
 
-It is available in [Debian](https://tracker.debian.org/pkg/python-bx) and Ubuntu:
+It is available in [Debian](https://tracker.debian.org/pkg/python-bx) and [Ubuntu](https://packages.ubuntu.com/python3-bx):
 
 ```sudo apt install python3-bx```
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ It is available in [bioconda](https://anaconda.org/bioconda/bx-python) (recommen
 
 ```conda install -c conda-forge -c bioconda bx-python```
 
+It is available in [Debian](https://tracker.debian.org/pkg/python-bx) and Ubuntu:
+
+```sudo apt install python3-bx```
+
 Or can be built from a checkout of the repository:
 
 ```python setup.py install```


### PR DESCRIPTION
Debian has a packag of bx-python, too. I just found that we missed the latest release tag and will update that later tonight.

The package is community maintained on https://salsa.debian.org/med-team/python-bx should there be any issues.