### PR TITLE
Index TwoBitFile sequences by str not bytes

### DIFF
--- a/lib/bx/seq/twobit_tests.py
+++ b/lib/bx/seq/twobit_tests.py
@@ -36,7 +36,6 @@ def test_random_subseq_matches(filename):
     with open(test_twobit, 'rb') as f:
         t = twobit.TwoBitFile(f)
         for k, s in expected.items():
-            k = k.encode()
             assert k in t.index
             # assert t.index[k].size == len(s)
             length = len(s)

--- a/scripts/gene_fourfold_sites.py
+++ b/scripts/gene_fourfold_sites.py
@@ -14,7 +14,6 @@ usage: %prog nibdir genefile [options]
 
 import os
 import re
-import string
 import sys
 
 from bx.cookbook import doc_optparse
@@ -123,7 +122,7 @@ def getnib(nibdir):
     return seqs
 
 
-REVMAP = string.maketrans("ACGTacgt", "TGCAtgca")
+REVMAP = str.maketrans("ACGTacgt", "TGCAtgca")
 
 
 def revComp(seq):

--- a/scripts/maf_tile.py
+++ b/scripts/maf_tile.py
@@ -15,7 +15,6 @@ usage: %prog tree maf_files...
     -m, --missingData: Inserts wildcards for missing block rows instead of '-'
 """
 
-import string
 import sys
 
 import bx.align as align
@@ -23,7 +22,7 @@ import bx.align.maf
 import bx.seq.nib
 from bx.cookbook import doc_optparse
 
-tree_tx = string.maketrans("(),", "   ")
+tree_tx = str.maketrans("(),", "   ")
 
 
 def main():

--- a/scripts/maf_tile_2.py
+++ b/scripts/maf_tile_2.py
@@ -29,7 +29,6 @@ usage: %prog list,of,species,to,keep seq_db_file indexed_maf_files ...
     -s, --strand:      Use strand information for intervals, reveres complement if '-'
 """
 
-import string
 import sys
 
 from cookbook import doc_optparse
@@ -38,7 +37,7 @@ import bx.align as align
 import bx.align.maf as maf
 import bx.seq.nib
 
-tree_tx = string.maketrans("(),", "   ")
+tree_tx = str.maketrans("(),", "   ")
 
 
 def main():

--- a/scripts/maf_tile_2bit.py
+++ b/scripts/maf_tile_2bit.py
@@ -27,7 +27,6 @@ usage: %prog list,of,species,to,keep ref.2bit indexed_maf_files ...
     -s, --strand:      Use strand information for intervals, reveres complement if '-'
 """
 
-import string
 import sys
 
 import bx.align as align
@@ -36,7 +35,7 @@ import bx.seq.nib
 import bx.seq.twobit
 from bx.cookbook import doc_optparse
 
-tree_tx = string.maketrans("(),", "   ")
+tree_tx = str.maketrans("(),", "   ")
 
 
 def main():
@@ -44,7 +43,7 @@ def main():
     options, args = doc_optparse.parse(__doc__)
     try:
         sources = args[0].translate(tree_tx).split()
-        ref_2bit = bx.seq.twobit.TwoBitFile(open(args[1]))
+        ref_2bit = bx.seq.twobit.TwoBitFile(open(args[1], "rb"))
         index = maf.MultiIndexed(args[2:])
 
         out = maf.Writer(sys.stdout)

--- a/scripts/maf_translate_chars.py
+++ b/scripts/maf_translate_chars.py
@@ -11,12 +11,11 @@ TODO: This could be much more general, should just take the translation table
 usage: %prog < maf > maf
 """
 
-import string
 import sys
 
 from bx.align import maf
 
-table = string.maketrans("#=X@", "-***")
+table = str.maketrans("#=X@", "-***")
 
 
 def main():


### PR DESCRIPTION
Fix https://github.com/bxlab/bx-python/issues/31 .

Also:
- Add some type annotations.
- Remove unused attributes of TwoBitSequence objects.
- Fix use of TwoBitFile in scripts and tests.
- Fix maketrans use in scripts.