### PR TITLE
From NumPy 1.24.0 ``np.float`` is deprecated

### DIFF
--- a/lib/bx/align/_epo.pyx
+++ b/lib/bx/align/_epo.pyx
@@ -112,9 +112,9 @@ def fastLoadChain(fname, hf):
             N.append( (int(line[0]), 0, 0) )
             s, t, q = zip( *N )
             data.append( (hd,
-                numpy.array(s, dtype=numpy.int),
-                numpy.array(t, dtype=numpy.int),
-                numpy.array(q, dtype=numpy.int)) )
+                numpy.array(s, dtype=int),
+                numpy.array(t, dtype=int),
+                numpy.array(q, dtype=int)) )
             assert hd.tEnd - hd.tStart == sum(s) + sum(t)
             assert hd.qEnd - hd.qStart == sum(s) + sum(q)
             fd.readline() # a blank line

--- a/scripts/bnMapper.py
+++ b/scripts/bnMapper.py
@@ -35,9 +35,9 @@ narrowPeak_t = np.dtype(
         ("id", np.str_, 100),
         ("score", np.int64),
         ("strand", np.str_, 1),
-        ("signalValue", np.float),
-        ("pValue", np.float),
-        ("qValue", np.float),
+        ("signalValue", float),
+        ("pValue", float),
+        ("qValue", float),
         ("peak", np.int64),
     ]
 )


### PR DESCRIPTION
I removed them to make bx-python compatible with last version of numpy but this drop support for numpy <1.20. I don't know which file I should modify.