### PR TITLE
post install testing

### DIFF
--- a/lib/bx/align/sitemask/sitemask_tests.py
+++ b/lib/bx/align/sitemask/sitemask_tests.py
@@ -6,7 +6,7 @@ import tempfile
 from io import StringIO
 
 import bx.align.maf
-from . import cpg
+from bx.align.sitemask import cpg
 
 test_maf_cpg = """##maf version=1 scoring=none
 a score=0

--- a/lib/bx/binned_array_tests.py
+++ b/lib/bx/binned_array_tests.py
@@ -11,7 +11,7 @@ from numpy import (
 )
 from numpy.random import random_sample as random
 
-from .binned_array import (
+from bx.binned_array import (
     BinnedArray,
     BinnedArrayWriter,
     FileBinnedArray,

--- a/lib/bx/interval_index_file_tests.py
+++ b/lib/bx/interval_index_file_tests.py
@@ -1,8 +1,8 @@
 import random
 from tempfile import mktemp
 
-from . import interval_index_file
-from .interval_index_file import Indexes
+from bx import interval_index_file
+from bx.interval_index_file import Indexes
 
 
 def test_offsets():

--- a/lib/bx/intervals/cluster_tests.py
+++ b/lib/bx/intervals/cluster_tests.py
@@ -1,14 +1,6 @@
-import os
-import sys
 import unittest
 
-try:
-    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-except Exception:
-    sys.path.insert(0, os.path.dirname(os.path.abspath(".")))
-
-# from bx.intervals.cluster import ClusterTree
-from .cluster import ClusterTree
+from bx.intervals.cluster import ClusterTree
 
 
 class TestCluster(unittest.TestCase):

--- a/lib/bx/misc/seekbzip2_tests.py
+++ b/lib/bx/misc/seekbzip2_tests.py
@@ -7,7 +7,7 @@ import os
 import random
 from codecs import encode
 
-from . import seekbzip2
+from bx.misc import seekbzip2
 
 F = None
 T = None

--- a/lib/bx/motif/io/transfac_tests.py
+++ b/lib/bx/motif/io/transfac_tests.py
@@ -2,7 +2,7 @@ from io import StringIO
 
 from numpy import allclose
 
-from . import transfac
+from bx.motif.io import transfac
 
 sample = """
 VV  TRANSFAC MATRIX TABLE, Rel.3.2 26-06-1997

--- a/lib/bx/motif/pwm_tests.py
+++ b/lib/bx/motif/pwm_tests.py
@@ -3,7 +3,7 @@ from numpy import (
     isnan,
 )
 
-from . import pwm
+from bx.motif import pwm
 
 
 def test_create():

--- a/lib/bx/seq/fasta_tests.py
+++ b/lib/bx/seq/fasta_tests.py
@@ -4,7 +4,7 @@ Tests for `bx.seq.fasta`.
 
 import unittest
 
-from . import fasta
+from bx.seq import fasta
 
 test_fa = "test_data/seq_tests/test.fa"
 

--- a/lib/bx/seq/nib_tests.py
+++ b/lib/bx/seq/nib_tests.py
@@ -4,7 +4,7 @@ Tests for `bx.seq.nib`.
 
 import unittest
 
-from . import nib
+from bx.seq import nib
 
 test_nib = "test_data/seq_tests/test.nib"
 

--- a/lib/bx/seq/qdna_tests.py
+++ b/lib/bx/seq/qdna_tests.py
@@ -4,7 +4,7 @@ Tests for `bx.seq.qdna`.
 
 import unittest
 
-from . import qdna
+from bx.seq import qdna
 
 test_qdna = "test_data/seq_tests/test.qdna"
 

--- a/lib/bx/seq/twobit_tests.py
+++ b/lib/bx/seq/twobit_tests.py
@@ -2,7 +2,7 @@ import random
 
 import pytest
 
-from . import twobit
+from bx.seq import twobit
 
 
 def quick_fasta_iter(f):


### PR DESCRIPTION
Depends on #92 

This allows Debian and others to run the unit tests against the installed Python package.

Ideally the various `*_tests.py` files in `lib` would also be under a single directory instead of scattered about; but we have a hack to cope with that in the Debian package for now.