### PR TITLE
Fix include for `strlen()`

### DIFF
--- a/src/pwm_utils.c
+++ b/src/pwm_utils.c
@@ -1,7 +1,7 @@
 
 #include <ctype.h>
 #include <stdio.h>
-#include <strings.h>
+#include <string.h>
 
 int symbol_match( char, char);
 int pattern_match( char*, char*, int);


### PR DESCRIPTION
In Debian, as of dpkg 1.22.6, we automatically add `-Werror=implicit-function-declaration`
to CFLAGS, which found this bug.
